### PR TITLE
systemd: prefer VPN DNS entries

### DIFF
--- a/update-systemd-network.sh
+++ b/update-systemd-network.sh
@@ -55,6 +55,7 @@ up)
     echo '[Match]'
     echo "Name=$IFNAME"
     echo '[Network]'
+    echo 'DNSDefaultRoute=true'
     for dns in "$IF_DNS_NAMESERVERS"; do
       echo "DNS=$dns"
     done


### PR DESCRIPTION
By setting `DNSDefaultRoute=true`, the VPN link's DNS is preferred over the main connection's DNS entries.